### PR TITLE
[0.3.1] Add `<PipelineRenderComponent context>` Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v0.3.1 - 2022/03/07
+
+-   `component`
+
+    -   **(BREAKING)** `component(..., {context: Map<string, any>})` — Updated to use `Map` instead of `Record` due to data loss of non-string keys.
+
+-   `PipelineRenderComponent`
+
+    -   `<PipelineRenderComponent context={Map<any, any>}>` — Added support for configuring the rendered Component's available [Svelte Contexts](https://svelte.dev/docs#run-time-svelte-getcontext).
+
 ## v0.3.0 - 2021/11/26
 
 -   **(BREAKING)** Changed Component namespace from `import {...} from "@novacbn/svelte-pipeline/repl";` -> `import {...} from "@novacbn/svelte-pipeline/components";`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "@novacbn/svelte-pipeline",
             "version": "0.3.0",
             "dependencies": {
-                "svelte": "^3.38.2"
+                "svelte": "^3.39.0"
             },
             "devDependencies": {
                 "@sveltejs/kit": "^1.0.0-next.134",
@@ -809,9 +809,9 @@
             }
         },
         "node_modules/svelte": {
-            "version": "3.38.2",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.38.2.tgz",
-            "integrity": "sha512-q5Dq0/QHh4BLJyEVWGe7Cej5NWs040LWjMbicBGZ+3qpFWJ1YObRmUDZKbbovddLC9WW7THTj3kYbTOFmU9fbg==",
+            "version": "3.39.0",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.39.0.tgz",
+            "integrity": "sha512-dcJCongL0cRkZWe9q+fde0T4HX8PksBywz2+EGDVIrdYdJaxTzrJu0RVeuDtL8Mx2hs4yn3W8zKPScuzG63hTg==",
             "engines": {
                 "node": ">= 8"
             }
@@ -1570,9 +1570,9 @@
             }
         },
         "svelte": {
-            "version": "3.38.2",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.38.2.tgz",
-            "integrity": "sha512-q5Dq0/QHh4BLJyEVWGe7Cej5NWs040LWjMbicBGZ+3qpFWJ1YObRmUDZKbbovddLC9WW7THTj3kYbTOFmU9fbg=="
+            "version": "3.39.0",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.39.0.tgz",
+            "integrity": "sha512-dcJCongL0cRkZWe9q+fde0T4HX8PksBywz2+EGDVIrdYdJaxTzrJu0RVeuDtL8Mx2hs4yn3W8zKPScuzG63hTg=="
         },
         "svelte-check": {
             "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "test:types": "tsc --noEmit"
     },
     "dependencies": {
-        "svelte": "^3.38.2"
+        "svelte": "^3.39.0"
     },
     "devDependencies": {
         "@sveltejs/kit": "^1.0.0-next.134",

--- a/src/lib/actions/component.ts
+++ b/src/lib/actions/component.ts
@@ -47,7 +47,7 @@ export interface IComponentOptions {
     /**
      * Represents the optional Svelte Context that will be passed onto the Component
      */
-    context: Record<any, any>;
+    context: Map<any, any>;
 
     /**
      * Represents the optional properties that will be passed into the Component
@@ -70,7 +70,7 @@ export function component(
     element: HTMLElement,
     options: Partial<IComponentOptions> = {}
 ): IComponentHandle {
-    let {on_destroy, on_error, on_mount, Component, context = {}, props = {}} = options;
+    let {on_destroy, on_error, on_mount, Component, context = new Map(), props = {}} = options;
     let component: SvelteComponent | null = null;
 
     element.setAttribute("data-pipeline-component", "true");
@@ -91,11 +91,11 @@ export function component(
             component = new Component({
                 target: element,
 
-                context: new Map(Object.entries(context)),
+                context,
                 props,
             });
         } catch (err) {
-            if (on_error) on_error(err);
+            if (on_error) on_error(err as Error);
             return;
         }
 
@@ -115,7 +115,7 @@ export function component(
             ({on_destroy, on_error, on_mount} = options);
 
             if (options.Component !== Component || options.context !== context) {
-                ({Component, context = {}, props = {}} = options);
+                ({Component, context = new Map(), props = {}} = options);
 
                 try_mount();
             } else if (options.props !== props) {

--- a/src/lib/components/PipelineRenderComponent.svelte
+++ b/src/lib/components/PipelineRenderComponent.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {SvelteComponent} from "svelte";
-    import {createEventDispatcher} from "svelte";
+    import {createEventDispatcher, getAllContexts} from "svelte";
 
     import {component} from "../actions/component";
     import {stylesheet} from "../actions/stylesheet";
@@ -25,6 +25,7 @@
     export let style: string | undefined = undefined;
     export {_class as class};
 
+    export let context: Map<any, any> = getAllContexts();
     export let pipeline: IPipelineSvelteStore;
 
     let evaluation: IPipelineSvelteEvaluated | null = null;
@@ -67,6 +68,7 @@
         on_destroy: on_component_destroy,
         on_error: on_component_error,
         on_mount: on_component_mount,
+        context,
         Component: evaluation?.module.exports.default ?? undefined,
     }}
 />


### PR DESCRIPTION
# CHANGELOG

-   `component`

    -   **(BREAKING)** `component(..., {context: Map<string, any>})` — Updated to use `Map` instead of `Record` due to data loss of non-string keys.

-   `PipelineRenderComponent`

    -   `<PipelineRenderComponent context={Map<any, any>}>` — Added support for configuring the rendered Component's available [Svelte Contexts](https://svelte.dev/docs#run-time-svelte-getcontext).